### PR TITLE
new generation for describing class fields

### DIFF
--- a/src/fields/array.py
+++ b/src/fields/array.py
@@ -9,18 +9,8 @@ class ArrayField(BaseField):
     def __typehint__(self) -> str:
         return f"list[{self.items.__typehint__}]"
 
-    def _get_description(self) -> str:
+    def _get_description(self) -> dict:
+        description_object = super()._get_description()
         if self.items.description is not None:
-            return f'    """{self.items.description}"""\n'
-        elif self.description is not None:
-            return f'    """{self.description}"""\n'
-        return ""
-
-    def to_field_class(self):
-        if self.required:
-            string = self._get_required_field_class()
-        else:
-            string = self._get_optional_field_class()
-
-        string += self._get_description()
-        return string
+            description_object["Description of item of array"] = self.items.description
+        return description_object

--- a/src/fields/base.py
+++ b/src/fields/base.py
@@ -62,9 +62,7 @@ class BaseField(Struct):
             description_string += f"    {description}\n"
         for key, value in description_object.items():
             description_string += f"    {key}: {value}\n"
-        if description_string:
-            return f'    """\n{description_string}    """\n'
-        return ""
+        return f'    """\n{description_string}    """\n'
 
     def to_field_class(self):
         if self.required:

--- a/src/fields/base.py
+++ b/src/fields/base.py
@@ -42,10 +42,29 @@ class BaseField(Struct):
             )
         return f"    {self.name}: typing.Optional[{self.__typehint__}] = None\n"
 
-    def _get_description(self) -> str:
+    def _get_description(self) -> dict:
         if self.description is None:
+            return {}
+        return {"description": self.description}
+
+    def _get_description_field_class(self) -> str:
+        description_object = self._get_description()
+        if not description_object:
             return ""
-        return f'    """{self.description}"""\n'
+
+        description = description_object.pop("description", None)
+        # If field has only description, return it
+        if description is not None and not description_object:
+            return f'    """{description}"""\n'
+
+        description_string = ""
+        if description is not None:
+            description_string += f"    {description}\n"
+        for key, value in description_object.items():
+            description_string += f"    {key}: {value}\n"
+        if description_string:
+            return f'    """\n{description_string}    """\n'
+        return ""
 
     def to_field_class(self):
         if self.required:
@@ -53,5 +72,5 @@ class BaseField(Struct):
         else:
             string = self._get_optional_field_class()
 
-        string += self._get_description()
+        string += self._get_description_field_class()
         return string

--- a/src/fields/boolean.py
+++ b/src/fields/boolean.py
@@ -36,5 +36,5 @@ class BooleanField(BaseField):
         else:
             string = self._get_optional_field_class()
 
-        string += self._get_description()
+        string += self._get_description_field_class()
         return string

--- a/src/fields/float.py
+++ b/src/fields/float.py
@@ -11,3 +11,11 @@ class FloatField(BaseField):
     @property
     def __typehint__(self) -> str:
         return "float"
+
+    def _get_description(self) -> dict:
+        description_object = super()._get_description()
+        if self.minimum is not None:
+            description_object["Minimum value"] = self.minimum
+        if self.maximum is not None:
+            description_object["Maximum value"] = self.maximum
+        return description_object

--- a/src/fields/integer.py
+++ b/src/fields/integer.py
@@ -17,6 +17,18 @@ class IntegerField(BaseField):
     def __typehint__(self) -> str:
         return "int"
 
+    def _get_description(self) -> dict:
+        description_object = super()._get_description()
+        if self.minimum is not None:
+            description_object["Minimum value"] = self.minimum
+        if self.maximum is not None:
+            description_object["Maximum value"] = self.maximum
+        if self.entity is not None:
+            description_object["Entity"] = self.entity
+        if self.format is not None:
+            description_object["Format"] = self.format
+        return description_object
+
     def _get_default_field_class(self) -> str:
         if self.default is None:
             raise ValueError("Default value is not defined")
@@ -38,5 +50,5 @@ class IntegerField(BaseField):
         else:
             string = self._get_optional_field_class()
 
-        string += self._get_description()
+        string += self._get_description_field_class()
         return string

--- a/src/fields/pattern.py
+++ b/src/fields/pattern.py
@@ -16,14 +16,9 @@ class PatternField(BaseField):
             return f"dict[str, {types}]"
         return f"dict[str, typing.Union[{types}]]"
 
-    def _get_description(self) -> str:
-        if self.description is not None:
-            string = f'    """\n    {self.description}\n'
-        else:
-            string = '    """\n'
-
-        string += "    Patterns of dict (as regexp) in the form of key-value:\n"
-        for pattern, field in self.patternProperties.items():
-            string += f"    {pattern}: {field.__typehint__}\n"
-        string += '    """\n'
-        return string
+    def _get_description(self) -> dict:
+        description_object = super()._get_description()
+        string = "Patterns of dict keys (as regexp)"
+        patterns = [pattern for pattern in self.patternProperties.keys()]
+        description_object[string] = ", ".join(patterns)
+        return description_object

--- a/src/fields/reference.py
+++ b/src/fields/reference.py
@@ -41,5 +41,5 @@ class ReferenceField(BaseField):
         else:
             string = self._get_optional_field_class()
 
-        string += self._get_description()
+        string += self._get_description_field_class()
         return string

--- a/src/fields/string.py
+++ b/src/fields/string.py
@@ -11,3 +11,11 @@ class StringField(BaseField):
     @property
     def __typehint__(self) -> str:
         return "str"
+
+    def _get_description(self) -> dict:
+        description_object = super()._get_description()
+        if self.maxLength is not None:
+            description_object["Max length"] = self.maxLength
+        if self.format is not None:
+            description_object["Format"] = self.format
+        return description_object

--- a/tests/test_fields/test_array.py
+++ b/tests/test_fields/test_array.py
@@ -27,7 +27,8 @@ class TestArrayField:
                         name="test_name", type="dict", description="Item description"
                     ),
                 },
-                '    test_name: typing.Optional[list[dict]] = None\n    """Item description"""\n',
+                "    test_name: typing.Optional[list[dict]] = None\n"
+                '    """\n    Description of item of array: Item description\n    """\n',
             ),
         ],
     )

--- a/tests/test_fields/test_base.py
+++ b/tests/test_fields/test_base.py
@@ -56,3 +56,47 @@ class TestBaseField:
         field = field_class(name="test_name", type="string", required=True)
         with pytest.raises(ValueError):
             field._get_optional_field_class()
+
+    def test__get_description(self):
+        field_class = get_implemented_class()
+        field = field_class(name="test_name", type="string", description="Test description")
+        assert field._get_description() == {"description": "Test description"}
+
+    def test__get_description_empty(self):
+        field_class = get_implemented_class()
+        field = field_class(name="test_name", type="string")
+        assert field._get_description() == {}
+
+    def test__get_description_field_class(self):
+        class DescriptionClass(BaseField):
+            @property
+            def __typehint__(self) -> str:
+                return "str"
+
+            def _get_description(self) -> dict:
+                return {"description": "Test description", "another": "Test another"}
+
+        field = DescriptionClass(name="test_name", type="string")
+        assert field._get_description_field_class() == (
+            '    """\n    Test description\n    another: Test another\n    """\n'
+        )
+
+    def test__get_description_field_class_only_description(self):
+        field_class = get_implemented_class()
+        field = field_class(name="test_name", type="string", description="Test description")
+        assert field._get_description_field_class() == '    """Test description"""\n'
+
+    def test__get_description_field_class_empty(self):
+        field_class = get_implemented_class()
+        field = field_class(name="test_name", type="string")
+        assert field._get_description_field_class() == ""
+
+    def test_to_field_class_required(self):
+        field_class = get_implemented_class()
+        field = field_class(name="test_name", type="string", required=True)
+        assert field.to_field_class() == "    test_name: str\n"
+
+    def test_to_field_class_no_required(self):
+        field_class = get_implemented_class()
+        field = field_class(name="test_name", type="string")
+        assert field.to_field_class() == "    test_name: typing.Optional[str] = None\n"

--- a/tests/test_fields/test_float.py
+++ b/tests/test_fields/test_float.py
@@ -11,9 +11,21 @@ class TestFloatField:
         [
             (MINIMUM_DATA, "    test_name: typing.Optional[float] = None\n"),
             ({**MINIMUM_DATA, "required": True}, "    test_name: float\n"),
-            ({**MINIMUM_DATA, "minimum": 1.0}, "    test_name: typing.Optional[float] = None\n"),
-            ({**MINIMUM_DATA, "minimum": 1}, "    test_name: typing.Optional[float] = None\n"),
-            ({**MINIMUM_DATA, "maximum": 1}, "    test_name: typing.Optional[float] = None\n"),
+            (
+                {**MINIMUM_DATA, "minimum": 1.0},
+                "    test_name: typing.Optional[float] = None\n"
+                '    """\n    Minimum value: 1.0\n    """\n',
+            ),
+            (
+                {**MINIMUM_DATA, "minimum": 1},
+                "    test_name: typing.Optional[float] = None\n"
+                '    """\n    Minimum value: 1\n    """\n',
+            ),
+            (
+                {**MINIMUM_DATA, "maximum": 1},
+                "    test_name: typing.Optional[float] = None\n"
+                '    """\n    Maximum value: 1\n    """\n',
+            ),
             (
                 {**MINIMUM_DATA, "description": "Test description"},
                 '    test_name: typing.Optional[float] = None\n    """Test description"""\n',

--- a/tests/test_fields/test_integer.py
+++ b/tests/test_fields/test_integer.py
@@ -12,10 +12,26 @@ class TestIntegerField:
             (MINIMUM_DATA, "    test_name: typing.Optional[int] = None\n"),
             ({**MINIMUM_DATA, "required": True}, "    test_name: int\n"),
             ({**MINIMUM_DATA, "default": 1}, "    test_name: int = 1\n"),
-            ({**MINIMUM_DATA, "minimum": 1}, "    test_name: typing.Optional[int] = None\n"),
-            ({**MINIMUM_DATA, "maximum": 1}, "    test_name: typing.Optional[int] = None\n"),
-            ({**MINIMUM_DATA, "entity": "owner"}, "    test_name: typing.Optional[int] = None\n"),
-            ({**MINIMUM_DATA, "format": "int64"}, "    test_name: typing.Optional[int] = None\n"),
+            (
+                {**MINIMUM_DATA, "minimum": 1},
+                "    test_name: typing.Optional[int] = None\n"
+                '    """\n    Minimum value: 1\n    """\n',
+            ),
+            (
+                {**MINIMUM_DATA, "maximum": 1},
+                "    test_name: typing.Optional[int] = None\n"
+                '    """\n    Maximum value: 1\n    """\n',
+            ),
+            (
+                {**MINIMUM_DATA, "entity": "owner"},
+                "    test_name: typing.Optional[int] = None\n"
+                '    """\n    Entity: owner\n    """\n',
+            ),
+            (
+                {**MINIMUM_DATA, "format": "int64"},
+                "    test_name: typing.Optional[int] = None\n"
+                '    """\n    Format: int64\n    """\n',
+            ),
             (
                 {**MINIMUM_DATA, "description": "Test description"},
                 '    test_name: typing.Optional[int] = None\n    """Test description"""\n',

--- a/tests/test_fields/test_pattern_properties.py
+++ b/tests/test_fields/test_pattern_properties.py
@@ -10,28 +10,26 @@ MINIMUM_DATA: dict = {
     "additionalProperties": False,
 }
 
-DEFAULT_DESCRIPTION = (
-    "\n    Patterns of dict (as regexp) in the form of key-value:\n    this_is_regexp: str\n"
-)
+DEFAULT_DESCRIPTION = "\n    Patterns of dict keys (as regexp): this_is_regexp"
 
 
-class TestPatterField:
+class TestPatternField:
     @pytest.mark.parametrize(
         "data, expected",
         [
             (
                 MINIMUM_DATA,
                 f"    test_name: typing.Optional[dict[str, str]] = None\n"
-                f'    """{DEFAULT_DESCRIPTION}    """\n',
+                f'    """{DEFAULT_DESCRIPTION}\n    """\n',
             ),
             (
                 {**MINIMUM_DATA, "required": True},
-                f"    test_name: dict[str, str]\n" f'    """{DEFAULT_DESCRIPTION}    """\n',
+                f"    test_name: dict[str, str]\n" f'    """{DEFAULT_DESCRIPTION}\n    """\n',
             ),
             (
                 {**MINIMUM_DATA, "description": "Test description"},
                 f"    test_name: typing.Optional[dict[str, str]] = None\n"
-                f'    """\n    Test description{DEFAULT_DESCRIPTION}    """\n',
+                f'    """\n    Test description{DEFAULT_DESCRIPTION}\n    """\n',
             ),
             (
                 {
@@ -42,7 +40,7 @@ class TestPatterField:
                     },
                 },
                 f"    test_name: typing.Optional[dict[str, typing.Union[str, int]]] = None\n"
-                f'    """{DEFAULT_DESCRIPTION}    this_is_regexp2: int\n    """\n',
+                f'    """{DEFAULT_DESCRIPTION}, this_is_regexp2\n    """\n',
             ),
         ],
     )

--- a/tests/test_fields/test_string.py
+++ b/tests/test_fields/test_string.py
@@ -11,8 +11,16 @@ class TestStringField:
         [
             (MINIMUM_DATA, "    test_name: typing.Optional[str] = None\n"),
             ({**MINIMUM_DATA, "required": True}, "    test_name: str\n"),
-            ({**MINIMUM_DATA, "maxLength": 1}, "    test_name: typing.Optional[str] = None\n"),
-            ({**MINIMUM_DATA, "format": "uri"}, "    test_name: typing.Optional[str] = None\n"),
+            (
+                {**MINIMUM_DATA, "maxLength": 1},
+                "    test_name: typing.Optional[str] = None\n"
+                '    """\n    Max length: 1\n    """\n',
+            ),
+            (
+                {**MINIMUM_DATA, "format": "uri"},
+                "    test_name: typing.Optional[str] = None\n"
+                '    """\n    Format: uri\n    """\n',
+            ),
             (
                 {**MINIMUM_DATA, "description": "Test description"},
                 '    test_name: typing.Optional[str] = None\n    """Test description"""\n',


### PR DESCRIPTION
For example. Formerly, object with this schema:
```json
"object": {
  "type": "object",
  "properties": {
    "user_id": {
      "type": "integer",
      "minimum": 0,
      "entity": "owner",
      "format": "int64",
      "required": true,
      "description": "Description"
    }
  },
  "additionalProperties": false
}
```
Generated into such a class:
```python
class Object(pydantic.BaseModel):
    user_id: int
    """Description"""
```
Now, class will be generated like this:
```python
class Object(pydantic.BaseModel):
    user_id: int
    """
    Description
    Minimum value: 0
    Entity: owner
    Format: int64
    """"
```